### PR TITLE
instrument(ui): AESTRA_WAVE_TRACE — waveform path/range/count telemetry

### DIFF
--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -690,7 +690,11 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     m_waveformPeaksL.clear();
     m_waveformPeaksR.clear();
 
-    static const bool waveTrace = std::getenv("AESTRA_WAVE_TRACE") != nullptr;
+    static const bool waveTrace = [] {
+        const char* v = std::getenv("AESTRA_WAVE_TRACE");
+        return v && v[0] != '\0' && v[0] != '0';
+    }();
+    static std::unordered_map<const void*, int> lastPath;
     const int pathId = (samplesPerPixel < static_cast<double>(Aestra::Audio::WaveformCache::DEFAULT_BASE_SAMPLES_PER_PEAK)) ? 0 : 1;
 
     if (samplesPerPixel < static_cast<double>(Aestra::Audio::WaveformCache::DEFAULT_BASE_SAMPLES_PER_PEAK)) {
@@ -706,9 +710,13 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
         if (!waveformCache || !waveformCache->isReady()) {
             // Fallback: faint center line
             if (waveTrace) {
+                bool transition = false;
+                auto it = lastPath.find(source);
+                if (it != lastPath.end() && it->second != 2) transition = true;
+                lastPath[source] = 2;
                 std::printf("[WaveZoom] spp=%.1f path=fallback transition=%d req=[%.0f,%.0f) got=0 visible=0 "
                             "contentRev=%llu src=%p\n",
-                            samplesPerPixel, pathId != 1 ? 1 : 0, sourceStart, sourceEnd,
+                            samplesPerPixel, transition ? 1 : 0, sourceStart, sourceEnd,
                             static_cast<unsigned long long>(source->getContentRevision()), (void*)source);
             }
             float centerY = audibleBounds.y + height * 0.5f;
@@ -729,7 +737,6 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
         // visible peak counts, per source revision. transition=true marks the
         // first frame after a path switch (direct<->cache<->fallback), where a
         // cache/path handoff race would surface. Env-gated: AESTRA_WAVE_TRACE=1
-        static std::unordered_map<const void*, int> lastPath;
         const char* pathName = (samplesPerPixel <
                                 static_cast<double>(Aestra::Audio::WaveformCache::DEFAULT_BASE_SAMPLES_PER_PEAK))
                                    ? "direct" : "cache";

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -669,11 +669,26 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     // remainder empty instead of stretching the old waveform across silence.
     AestraUI::NUIRect audibleBounds = bounds;
     const double visibleOutputFrames = visibleOutputEnd - visibleOutputStart;
+    static const bool waveTrace = [] {
+        const char* v = std::getenv("AESTRA_WAVE_TRACE");
+        return v && v[0] != '\0' && v[0] != '0';
+    }();
+    static std::unordered_map<const void*, int> lastPath;
     const double availableOutputEnd =
         (static_cast<double>(totalFrames) - scaledSourceOffset) / varispeed;
     if (visibleOutputFrames > 0.0 && availableOutputEnd < visibleOutputEnd) {
         const double audibleOutputFrames = std::max(0.0, availableOutputEnd - visibleOutputStart);
-        audibleBounds.width *= static_cast<float>(std::clamp(audibleOutputFrames / visibleOutputFrames, 0.0, 1.0));
+        const double shrinkFraction = std::clamp(audibleOutputFrames / visibleOutputFrames, 0.0, 1.0);
+        audibleBounds.width *= static_cast<float>(shrinkFraction);
+        if (waveTrace) {
+            // #858: the source-audio-exhausted clamp bit. If blank tails
+            // correlate with this line, the clip's timeline extent overhangs
+            // its actual source audio at this viewport position.
+            std::printf("[WaveShrink] shrinkFraction=%.4f availOutEnd=%.0f visOutEnd=%.0f "
+                        "tlFrames=%.0f srcOff=%.0f vspeed=%.3f totalFrames=%zu\n",
+                        shrinkFraction, availableOutputEnd, visibleOutputEnd, timelineFrames,
+                        scaledSourceOffset, varispeed, totalFrames);
+        }
     }
     if (audibleBounds.width <= 0.0f)
         return;
@@ -695,11 +710,6 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     m_waveformPeaksL.clear();
     m_waveformPeaksR.clear();
 
-    static const bool waveTrace = [] {
-        const char* v = std::getenv("AESTRA_WAVE_TRACE");
-        return v && v[0] != '\0' && v[0] != '0';
-    }();
-    static std::unordered_map<const void*, int> lastPath;
     const int pathId = (samplesPerPixel < static_cast<double>(Aestra::Audio::WaveformCache::DEFAULT_BASE_SAMPLES_PER_PEAK)) ? 0 : 1;
 
     if (samplesPerPixel < static_cast<double>(Aestra::Audio::WaveformCache::DEFAULT_BASE_SAMPLES_PER_PEAK)) {
@@ -787,6 +797,27 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
                     m_waveformPeaksL.size(), visible, ampMax, spanTop, spanBottom,
                     audibleBounds.y, audibleBounds.height,
                     static_cast<unsigned long long>(source->getContentRevision()), (void*)source);
+        // #858 blank-tail chain: the right edge through every transformation,
+        // beats -> output frames -> source samples -> screen px. first wrong
+        // value localizes the layer. clipRight/audibleRight are the clip rect
+        // and the (possibly shrunk) drawable rect right edges in screen px.
+        const double clipStartBeat = static_cast<double>(clip.startBeat);
+        const double clipEndBeat = clipStartBeat + static_cast<double>(clip.durationBeats);
+        const double visStartBeat = clipStartBeat + static_cast<double>(offsetRatio) * static_cast<double>(clip.durationBeats);
+        const double visEndBeat = visStartBeat + static_cast<double>(visibleRatio) * static_cast<double>(clip.durationBeats);
+        const double pxPerSample = (sourceEnd > sourceStart)
+                                       ? static_cast<double>(audibleBounds.width) / (sourceEnd - sourceStart)
+                                       : 0.0;
+        std::printf("[WaveChain] clipBeats=[%.3f,%.3f] visBeats=[%.3f,%.3f] offR=%.4f visR=%.4f "
+                    "tlFrames=%.0f availOutEnd=%.0f visOutEnd=%.0f srcOff=%.0f vspeed=%.3f "
+                    "totalFrames=%zu dur=%.2fs req=[%.0f,%.0f) numBars=%d got=%zu "
+                    "pxPerSmp=%.4f destX=%.1f destW=%.1f clipRight=%.1f audibleRight=%.1f path=%s\n",
+                    clipStartBeat, clipEndBeat, visStartBeat, visEndBeat,
+                    static_cast<double>(offsetRatio), static_cast<double>(visibleRatio),
+                    timelineFrames, availableOutputEnd, visibleOutputEnd, scaledSourceOffset, varispeed,
+                    totalFrames, totalFrames / std::max(1.0, sampleRate), sourceStart, sourceEnd, numBars,
+                    m_waveformPeaksL.size(), pxPerSample, audibleBounds.x, audibleBounds.width,
+                    bounds.x + bounds.width, audibleBounds.x + audibleBounds.width, pathName);
     }
 
     // Always one combined waveform. Split L/R lanes read as a thin "doubled"

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -105,6 +105,11 @@ std::string truncateClipLabel(const std::string& text, float availableWidth, flo
     return text.substr(0, maxChars - 2) + "..";
 }
 
+// Display gain so moderate-level audio fills the clip height rather than a thin
+// band; clamped so it never overshoots the lane. Lives at file scope so the
+// AESTRA_WAVE_TRACE span assertion maps peaks exactly like drawChannelWaveform().
+constexpr float kWaveDisplayGain = 1.45f;
+
 TrackSelectionIntent selectionIntentFor(const AestraUI::NUIMouseEvent& event) {
     const bool toggleModifier =
         (event.modifiers & AestraUI::NUIModifiers::Ctrl) || (event.modifiers & AestraUI::NUIModifiers::Super);
@@ -734,9 +739,10 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
 
     if (waveTrace) {
         // #858 zoom instrumentation: path, requested range, returned vs
-        // visible peak counts, per source revision. transition=true marks the
-        // first frame after a path switch (direct<->cache<->fallback), where a
-        // cache/path handoff race would surface. Env-gated: AESTRA_WAVE_TRACE=1
+        // visible peak counts, peak amplitude and the mapped pixel span, per
+        // source revision. transition=true marks the first frame after a path
+        // switch (direct<->cache<->fallback), where a cache/path handoff race
+        // would surface. Env-gated: AESTRA_WAVE_TRACE=1
         const char* pathName = (samplesPerPixel <
                                 static_cast<double>(Aestra::Audio::WaveformCache::DEFAULT_BASE_SAMPLES_PER_PEAK))
                                    ? "direct" : "cache";
@@ -745,13 +751,41 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
         if (it != lastPath.end() && it->second != pathId) transition = true;
         lastPath[source] = pathId;
         size_t visible = 0;
+        float ampMax = 0.0f;
         for (const auto& pk : m_waveformPeaksL) {
             if (pk.max != 0.0f || pk.min != 0.0f) ++visible;
+            ampMax = std::max(ampMax, std::max(std::fabs(pk.min), std::fabs(pk.max)));
+        }
+        // #858 amplitude-vs-mapping discriminator: ampMax is the largest |min|/|max|
+        // among returned peaks; span is the vertical pixel range drawChannelWaveform
+        // will paint for them (same gain/clamp/center mapping). ampMax ~ 0 with a
+        // ~1px span means the peak data collapsed; full-scale ampMax with a tiny
+        // span means the Y mapping or bounds collapsed.
+        const float traceCenterY = audibleBounds.y + audibleBounds.height * 0.5f;
+        const float traceHalfH = std::max(1.0f, audibleBounds.height * 0.5f - 2.0f);
+        float spanTop = std::numeric_limits<float>::max();
+        float spanBottom = std::numeric_limits<float>::lowest();
+        if (numChannels > 1) {
+            for (const auto& pk : m_waveformPeaksR) {
+                ampMax = std::max(ampMax, std::max(std::fabs(pk.min), std::fabs(pk.max)));
+            }
+        }
+        for (const auto& pk : m_waveformPeaksL) {
+            const float normMin = std::max(-1.0f, std::min(1.0f, pk.min * kWaveDisplayGain));
+            const float normMax = std::max(-1.0f, std::min(1.0f, pk.max * kWaveDisplayGain));
+            spanTop = std::min(spanTop, traceCenterY - normMax * traceHalfH);
+            spanBottom = std::max(spanBottom, traceCenterY - normMin * traceHalfH);
+        }
+        if (spanTop > spanBottom) { // no peaks: report an empty span at rect center
+            spanTop = traceCenterY;
+            spanBottom = traceCenterY;
         }
         std::printf("[WaveZoom] spp=%.1f path=%s transition=%d req=[%.0f,%.0f) got=%zu visible=%zu "
+                    "ampMax=%.4f span=[%.1f..%.1f]px rect=[y=%.1f h=%.1f] "
                     "contentRev=%llu src=%p\n",
                     samplesPerPixel, pathName, transition ? 1 : 0, sourceStart, sourceEnd,
-                    m_waveformPeaksL.size(), visible,
+                    m_waveformPeaksL.size(), visible, ampMax, spanTop, spanBottom,
+                    audibleBounds.y, audibleBounds.height,
                     static_cast<unsigned long long>(source->getContentRevision()), (void*)source);
     }
 
@@ -800,9 +834,8 @@ void TrackUIComponent::drawChannelWaveform(AestraUI::NUIRenderer& renderer, floa
     m_waveformTopPts.reserve(static_cast<size_t>(numPoints));
     m_waveformBottomPts.reserve(static_cast<size_t>(numPoints));
 
-    // Display gain so moderate-level audio fills the clip height rather than a
-    // thin band; clamped so it never overshoots the lane.
-    constexpr float kWaveDisplayGain = 1.45f;
+    // Display gain is the file-scope kWaveDisplayGain, shared with the
+    // AESTRA_WAVE_TRACE span assertion so both map peaks identically.
     for (int i = 0; i < numPoints; ++i) {
         const auto& peak = peaks[i];
         float normMin = std::max(-1.0f, std::min(1.0f, peak.min * kWaveDisplayGain));
@@ -1048,9 +1081,9 @@ void TrackUIComponent::drawSampleClipHeader(AestraUI::NUIRenderer& renderer, con
     const float headerRight = clipBounds.right() - (seamRight ? 0.0f : 1.0f);
     const AestraUI::NUIRect headerRect(headerLeft, clipBounds.y + 1.0f,
                                        std::max(0.0f, headerRight - headerLeft), kClipHeaderHeight);
-    // Own opaque title strip (the waveform lives below it, not behind it), with a
-    // divider so the label band reads as its own section.
-    const auto headerFill = themeManager.getColor("backgroundPrimary").withAlpha(clipSelected ? 0.98f : 0.94f);
+    // Translucent scrim: the filename must read over the full-height waveform
+    // behind it while the wave stays visible through the label zone.
+    const auto headerFill = themeManager.getColor("backgroundPrimary").withAlpha(clipSelected ? 0.80f : 0.68f);
     renderer.fillRoundedRect(headerRect, clipRadius - 1.0f, headerFill);
     constexpr float kSeamOverlap = 1.0f;
     const float seamFillWidth = clipRadius + kSeamOverlap;
@@ -1188,19 +1221,22 @@ void TrackUIComponent::drawClipAtPosition(AestraUI::NUIRenderer& renderer, const
                     drawPatternClipForClip(renderer, insetClippedClipBounds, insetFullClipBounds, clip);
                 } else {
                     drawSampleClipForClip(renderer, insetClippedClipBounds, insetFullClipBounds, clip, seamLeft, seamRight);
-                    // The label gets its own reserved strip at the top; the waveform
-                    // fills the whole area BELOW it (bold + gained, so it's full, not
-                    // squashed under the label).
-                    constexpr float kHeaderStripH = 16.0f;
+                    // The waveform spans the FULL clip body; the header renders as
+                    // a translucent scrim over it (see drawSampleClipHeader).
+                    // Reserving a strip below the label boxed the wave into the
+                    // leftover ~18px, where moderate-level audio rendered as a
+                    // thin band pinned under the filename instead of a clip-body
+                    // waveform (#858).
                     const float waveformPadLeft = seamLeft ? 0.0f : 3.0f;
                     const float waveformPadRight = seamRight ? 0.0f : 3.0f;
+                    constexpr float waveformPadTop = 2.0f;
                     constexpr float waveformPadBottom = 3.0f;
-                    const float waveTop = insetClippedClipBounds.y + kHeaderStripH;
                     const AestraUI::NUIRect waveformInsideClip(
                         insetClippedClipBounds.x + waveformPadLeft,
-                        waveTop + 1.0f,
+                        insetClippedClipBounds.y + waveformPadTop,
                         std::max(1.0f, insetClippedClipBounds.width - waveformPadLeft - waveformPadRight),
-                        std::max(1.0f, (insetClippedClipBounds.bottom() - waveformPadBottom) - (waveTop + 1.0f))
+                        std::max(1.0f, (insetClippedClipBounds.bottom() - waveformPadBottom) -
+                                           (insetClippedClipBounds.y + waveformPadTop))
                     );
                     drawWaveformForClip(renderer, waveformInsideClip, clip, offsetRatio, visibleRatio);
                     drawSampleClipHeader(renderer, insetClippedClipBounds, clip, seamLeft, seamRight);

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -690,6 +690,9 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     m_waveformPeaksL.clear();
     m_waveformPeaksR.clear();
 
+    static const bool waveTrace = std::getenv("AESTRA_WAVE_TRACE") != nullptr;
+    const int pathId = (samplesPerPixel < static_cast<double>(Aestra::Audio::WaveformCache::DEFAULT_BASE_SAMPLES_PER_PEAK)) ? 0 : 1;
+
     if (samplesPerPixel < static_cast<double>(Aestra::Audio::WaveformCache::DEFAULT_BASE_SAMPLES_PER_PEAK)) {
         // Zoomed past the finest mip level: compute peaks directly from the
         // buffer. Bounded work — at most base-mip samples per visible pixel.
@@ -702,6 +705,12 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
         auto waveformCache = source->getWaveformCache();
         if (!waveformCache || !waveformCache->isReady()) {
             // Fallback: faint center line
+            if (waveTrace) {
+                std::printf("[WaveZoom] spp=%.1f path=fallback transition=%d req=[%.0f,%.0f) got=0 visible=0 "
+                            "contentRev=%llu src=%p\n",
+                            samplesPerPixel, pathId != 1 ? 1 : 0, sourceStart, sourceEnd,
+                            static_cast<unsigned long long>(source->getContentRevision()), (void*)source);
+            }
             float centerY = audibleBounds.y + height * 0.5f;
             renderer.drawLine(AestraUI::NUIPoint(audibleBounds.x, centerY),
                               AestraUI::NUIPoint(audibleBounds.x + audibleBounds.width, centerY), 1.0f,
@@ -713,6 +722,30 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
         if (numChannels > 1) {
             waveformCache->getPeaksForRangePrecise(1, sourceStart, sourceEnd, numBars, m_waveformPeaksR);
         }
+    }
+
+    if (waveTrace) {
+        // #858 zoom instrumentation: path, requested range, returned vs
+        // visible peak counts, per source revision. transition=true marks the
+        // first frame after a path switch (direct<->cache<->fallback), where a
+        // cache/path handoff race would surface. Env-gated: AESTRA_WAVE_TRACE=1
+        static std::unordered_map<const void*, int> lastPath;
+        const char* pathName = (samplesPerPixel <
+                                static_cast<double>(Aestra::Audio::WaveformCache::DEFAULT_BASE_SAMPLES_PER_PEAK))
+                                   ? "direct" : "cache";
+        bool transition = false;
+        auto it = lastPath.find(source);
+        if (it != lastPath.end() && it->second != pathId) transition = true;
+        lastPath[source] = pathId;
+        size_t visible = 0;
+        for (const auto& pk : m_waveformPeaksL) {
+            if (pk.max != 0.0f || pk.min != 0.0f) ++visible;
+        }
+        std::printf("[WaveZoom] spp=%.1f path=%s transition=%d req=[%.0f,%.0f) got=%zu visible=%zu "
+                    "contentRev=%llu src=%p\n",
+                    samplesPerPixel, pathName, transition ? 1 : 0, sourceStart, sourceEnd,
+                    m_waveformPeaksL.size(), visible,
+                    static_cast<unsigned long long>(source->getContentRevision()), (void*)source);
     }
 
     // Always one combined waveform. Split L/R lanes read as a thin "doubled"

--- a/Tests/AestraAudio/WaveformCacheTest.cpp
+++ b/Tests/AestraAudio/WaveformCacheTest.cpp
@@ -350,6 +350,62 @@ bool testAsymmetricWaveform() {
     return true;
 }
 
+// 12. Coarse-mip scale invariants: peak amplitude must survive aggregation and
+// high-spp retrieval — zoomed-out clip rendering queries the coarsest mip
+// (spp ~ 8600-10430 was the reported collapse regime), so a scale/interleave
+// defect there reads as vertically collapsed waveforms.
+bool testCoarseMipScalePreserved() {
+    const SampleIndex numFrames = 48000;
+    const uint32_t numChannels = 2;
+    std::vector<float> data(static_cast<size_t>(numFrames) * numChannels, 0.0f);
+    for (SampleIndex f = 0; f < numFrames; ++f) {
+        const double t = static_cast<double>(f) / 48000.0;
+        const double l = 0.8 * std::sin(2.0 * 3.14159265358979 * 220.0 * t);
+        const double r = 0.6 * std::sin(2.0 * 3.14159265358979 * 331.0 * t + 0.7);
+        data[static_cast<size_t>(f) * numChannels + 0] = static_cast<float>(l);
+        data[static_cast<size_t>(f) * numChannels + 1] = static_cast<float>(r);
+    }
+
+    // Production defaults: base 64 samples/peak, 4 levels (64/256/1024/4096)
+    WaveformCache cache;
+    cache.buildFromRaw(data.data(), numFrames, numChannels);
+    if (!cache.isReady()) return fail("coarse mip: cache should be ready");
+
+    float referenceMaxAbs = 0.0f;
+    for (size_t i = 0; i < data.size(); i += numChannels) {
+        referenceMaxAbs = std::max(referenceMaxAbs, std::fabs(data[i]));
+    }
+
+    // Zoomed-out query: spp ~ 600 over 80 px selects the coarsest mip bucketing
+    std::vector<WaveformPeak> coarse;
+    cache.getPeaksForRangePrecise(0, 0.0, static_cast<double>(numFrames), 80, coarse);
+    if (coarse.size() != 80) return fail("coarse mip: expected 80 peaks");
+
+    float coarseMaxAbs = 0.0f;
+    for (const auto& pk : coarse) {
+        if (pk.min > pk.max) return fail("coarse mip: min/max swapped");
+        coarseMaxAbs = std::max(coarseMaxAbs, std::max(std::fabs(pk.min), std::fabs(pk.max)));
+    }
+
+    // Aggregated min/max must track the true source extreme (within the
+    // sample-grid resolution of a 220 Hz sine at 48 kHz), never collapse.
+    if (coarseMaxAbs > referenceMaxAbs + 1.0e-3f) return fail("coarse mip exceeded source amplitude");
+    if (coarseMaxAbs < referenceMaxAbs - 1.0e-3f) return fail("coarse mip lost peak amplitude");
+
+    // Finest-level query must agree on scale (no per-level scale drift)
+    std::vector<WaveformPeak> fine;
+    cache.getPeaksForRangePrecise(0, 0.0, 5120.0, 80, fine); // spp = 64 -> level 0
+    float fineMaxAbs = 0.0f;
+    for (const auto& pk : fine) {
+        if (pk.min > pk.max) return fail("fine mip: min/max swapped");
+        fineMaxAbs = std::max(fineMaxAbs, std::max(std::fabs(pk.min), std::fabs(pk.max)));
+    }
+    if (fineMaxAbs > referenceMaxAbs + 1.0e-3f) return fail("fine mip exceeded source amplitude");
+    if (fineMaxAbs < referenceMaxAbs - 1.0e-3f) return fail("fine mip lost peak amplitude");
+
+    return true;
+}
+
 } // namespace
 
 int main() {
@@ -368,6 +424,7 @@ int main() {
     ok &= testVeryShortFile();
     ok &= testSilentAudio();
     ok &= testAsymmetricWaveform();
+    ok &= testCoarseMipScalePreserved();
 
     if (ok) {
         std::cout << "AestraWaveformCacheTest: PASS\n";


### PR DESCRIPTION
## Summary
Env-gated (AESTRA_WAVE_TRACE=1) per-clip-per-frame trace answering one question: at a problematic zoom, does the renderer RECEIVE incomplete waveform data (got≈0, cache missing) or receive correct data and clip/collapse it (got==expected, visible<got)? Logs path (direct<64spp / cache / fallback), requested range, got vs visible, contentRevision, source identity, and transition=true on the first frame after a path switch — where a cache/path handoff race would surface. Zero cost when unset.

## Why
#858 cause 5: zoom-dependent waveform visibility. Instrument before touching the renderer; a cutoff at exactly spp=64 is a different bug than one merely correlating with zoom.

## Testing performed
Headless Aestra target builds clean (-j2, 0 errors). Runtime observation is manual by nature — reproduce with AESTRA_WAVE_TRACE=1 and compare one notch above/below the cutoff zoom.

## Producer note
None

## Decision citation
Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 3393b02
Kind: corrective

Ref #858

## Risk / rollback notes
Trace-only change behind env flag; no behavior change when unset. Rollback = revert commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added environment-gated (`AESTRA_WAVE_TRACE=1`) waveform telemetry for rendering paths, path transitions, requested ranges, source identity, revisions, amplitude, mapped spans, and drawable geometry.
- Added full beat-to-pixel tracing and `WaveShrink` diagnostics for source-exhaustion clamping.
- Expanded the waveform drawable rectangle to the full clip body and changed the header to a translucent scrim. This fixes zoom-dependent visibility issues.
- Added a regression test for coarse and fine waveform mip levels, including amplitude bounds, min/max ordering, and peak counts.
- Kept tracing disabled by default and preserved behavior when tracing is disabled.
- Made no public or exported API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->